### PR TITLE
ポートをgatsby serve用に展開

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ FROM node:14.16.1-alpine3.13
 WORKDIR /home/node/app
 RUN apk update && apk add git && \
 apk add --no-cache bash && \
-apk add make nasm autoconf automake libtool dpkg pkgconfig libpng libpng-dev g++
+apk add make nasm autoconf automake libtool dpkg pkgconfig libpng libpng-dev g++ curl
 RUN yarn global add gatsby-cli
-EXPOSE 8000
+EXPOSE 8000 9000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     container_name: gatsby
     ports:
       - 8000:8000
+      - 8001:9000
     volumes:
       - .:/home/node/app
     environment:


### PR DESCRIPTION
```
gatsby build
gatsby serve -H 0.0.0.0
```
上記でビルドしてserveする際に、`9000` でdocker内部にサービス展開されるため、
こちらポートをローカル端末 `8001`に対応させる。